### PR TITLE
Downgrade Uber version to support Operation v1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.iml
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
-  - 2.4.1
+  - 2.3.1
 before_install: gem install bundler -v 1.12.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.3.3
+  - 2.4.1
 before_install: gem install bundler -v 1.12.5

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It allows to run both old TRB 1.1 operations along with new or refactored 2.x co
 Your exisiting application's `Gemfile` should point to the new `trailblazer` gem.
 
 ```ruby
-gem "trailblazer", ">= 2.0.4"
+gem "trailblazer", ">= 2.0.6"
 gem "trailblazer-compat"
 ```
 

--- a/lib/trailblazer/compat/version.rb
+++ b/lib/trailblazer/compat/version.rb
@@ -1,5 +1,5 @@
 module Trailblazer
   module Compat
-    VERSION = "0.2.0"
+    VERSION = "0.1.1"
   end
 end

--- a/lib/trailblazer/compat/version.rb
+++ b/lib/trailblazer/compat/version.rb
@@ -1,5 +1,5 @@
 module Trailblazer
   module Compat
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/trailblazer-compat.gemspec
+++ b/trailblazer-compat.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # spec.add_dependency "trailblazer", ">= 1.2.0", "< 1.3.0"
+  spec.add_dependency "trailblazer", "~> 2.0"
+  spec.add_dependency "uber", "~> 0.0.15"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Uber 0.1.0 causes undefined `class_builder` method