### PR TITLE
Fix recursive run_v2 / run issue

### DIFF
--- a/lib/trailblazer/1.1/rails/railtie.rb
+++ b/lib/trailblazer/1.1/rails/railtie.rb
@@ -11,10 +11,12 @@ else
           application_controller = super
 
           v2_Controller = Trailblazer::Rails::Controller
+          v2_Controller.class_eval do
+            alias_method :run_v2, :run
+          end
 
           application_controller.class_eval do
             include v2_Controller # if Trailblazer::Operation.const_defined?(:Controller) # from V2.
-            alias_method :run_v2, :run
             include Trailblazer::V1_1::Operation::Controller
           end
         end


### PR DESCRIPTION
Hi there!

This is an excerpt from our current app stack, what seem to related the most.

* ruby (2.5.3)
* rails (5.2.1)
* trailblazer (2.0.7)
* trailblazer-rails (1.0.10)
* trailblazer-compat (0.1.3)

As you can guess we have Trb1 and Trb2 operations. Trb2 operations that we slowly convert from 1st version get called in controllers using `form`, `present`, `run`.

After `trailblazer-compat` and v2 operations were introduced we did have sporadical issues of "stack level too deep" where `run_v2` calls `run` which calls `run_v2` etc. This only happened with `run` and Trb2 operations. We didn't really look for a stable way to reproduce the issue because it only happens in development and server restart usually helped.

After updating to Ruby 2.5.3 and Rails 5.2.1 we now see this issue constantly in development. 

To be honest, I'm not entirely sure how exactly this breaks, but aliasing `run` outside of application controller does help and looks like functionally it does the same thing.

For now, our workaround is basically monkey patching `Trailblazer::V1_1::Railtie::ExtendApplicationController` with this fix.